### PR TITLE
Adds lang attribute to highlighted blocks (optional)

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -48,7 +48,8 @@ https://highlightjs.org/
     classPrefix: 'hljs-',
     tabReplace: null,
     useBR: false,
-    languages: undefined
+    languages: undefined,
+    langAttribute: true
   };
 
 
@@ -639,6 +640,8 @@ https://highlightjs.org/
 
     block.innerHTML = result.value;
     block.className = buildClassName(block.className, language, result.language);
+    if(options.langAttribute)
+       block.setAttribute('data-lang',result.language);
     block.result = {
       language: result.language,
       re: result.relevance


### PR DESCRIPTION
Based on options.langAttribute (boolean), adds a data-lang attribute to highlighted blocks. The idea behind this attribute is to provide an easy way to retrieve the language string literal from CSS.
So it can be used from stylesheets like the following to add a nice language label.
hljs:before{ content: attr(data-lang); }